### PR TITLE
feat: add multi-dot support for Day component

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ import { Calendar } from 'react-native-calendario';
 | **`disableRange`**         | Turn off range date selection          | no                   | false         | boolean          |
 | **`firstDayMonday`**       | Monday as first day of the week        | no                   | false         | boolean          |
 | **`monthHeight`**          | Change Month row height                | no                   | 370           | number           |
+| **`markedDays`**           | Multi-dot support on Day component     | no                   | undefined     | MarkedDays       |
 | **`disabledDays`**         | Disabled days                          | no                   | null          | {[string]: any } |
 | **`renderDayContent`**     | Render custom Day content              | no                   | null          | Function         |
 | **`extraData`**            | FlatList extraData                     | no                   | null          | any              |

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -15,6 +15,7 @@ import {
   RangeType,
 } from 'react-native-calendario';
 import moment from 'moment';
+import { MarkedDays } from 'react-native-month';
 
 const THEME: ThemeType = {
   monthTitleTextStyle: {
@@ -100,6 +101,21 @@ const ALTERNATIVE_STATE = {
   endDate: moment(END_DATE_2, FORMAT).toDate(),
   minDate: moment(MIN_DATE_2, FORMAT).toDate(),
   maxDate: moment(MAX_DATE_2, FORMAT).toDate(),
+};
+
+const markedDays: MarkedDays = {
+  '2020-03-12': {
+    dots: [
+      {
+        color: 'red',
+        selectedColor: 'green',
+      },
+      {
+        color: 'blue',
+        selectedColor: 'yellow',
+      },
+    ],
+  },
 };
 
 export default class App extends React.PureComponent<Props, State> {
@@ -266,6 +282,7 @@ export default class App extends React.PureComponent<Props, State> {
                   startDate={this.state.startDate}
                   endDate={this.state.endDate}
                   startingMonth="2020-01-10"
+                  markedDays={markedDays}
                   monthHeight={370}
                   numberOfMonths={12}
                   initialListSize={4}

--- a/example/app.json
+++ b/example/app.json
@@ -3,10 +3,7 @@
     "name": "react-native-calendario",
     "slug": "react-native-calendario",
     "privacy": "public",
-    "platforms": [
-      "ios",
-      "android"
-    ],
+    "platforms": ["ios", "android"],
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -16,9 +13,6 @@
       "backgroundColor": "#ffffff"
     },
     "packagerOpts": {
-      "assetExts": [
-        "ttf"
-      ],
       "config": "./metro.config.js",
       "projectRoots": ""
     }

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-39.0.3.tar.gz",
-    "react-native-month": "1.0.3"
+    "react-native-month": "1.0.4"
   },
   "devDependencies": {
     "babel-plugin-module-resolver": "4.0.0",

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "jsx": "react-native",
+    "target": "esnext",
+    "lib": [
+      "esnext"
+    ],
+    "paths": {
+      "react-native-calendario": [
+        "../src/index"
+      ]
+    },
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node"
+  }
+}

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5556,10 +5556,10 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
-react-native-month@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-month/-/react-native-month-1.0.3.tgz#76738fd77f8abe704fa5312f4ad0350822f0c309"
-  integrity sha512-RoD7/ingkugJ1T+bu2Q9+40AKfbhfjuwQwNtkPjxekOWQYXp8PDQvSgPsVcV9KlhwIKyFWroaOfyBp1XgvjaDw==
+react-native-month@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-month/-/react-native-month-1.0.4.tgz#7c55f35e7adacc071e56530350b60718d5722a89"
+  integrity sha512-oABtBzkGgS/QIURzXfW5TZUoMDeNSEruQEcO6HEY+L86zgyfxRoc38vHjh0y6CkZj0qvKHBC4oVQqk99ExnrBQ==
 
 react-native-safe-area-context@3.1.4:
   version "3.1.4"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/maggialejandro/react-native-calendario#readme",
   "dependencies": {
     "moment": "2.29.1",
-    "react-native-month": "1.0.3"
+    "react-native-month": "1.0.4"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -278,6 +278,7 @@ export default class Calendar extends React.Component<CalendarProps, State> {
         height={this.props.monthHeight}
         firstDayMonday={this.props.firstDayMonday}
         renderDayContent={this.props.renderDayContent}
+        markedDays={this.props.markedDays}
         minDate={this.props.minDate}
         maxDate={this.props.maxDate}
         startDate={this.state.startDate}

--- a/src/components/Month/index.tsx
+++ b/src/components/Month/index.tsx
@@ -122,6 +122,7 @@ export default React.memo<Props>(
           endDate={props.endDate}
           firstDayMonday={props.firstDayMonday}
           locale={props.locale}
+          markedDays={props.markedDays}
           maxDate={max}
           minDate={min}
           onPress={props.onPress}

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,5 +1,6 @@
 import { ComponentType, RefObject } from 'react';
 import { FlatList, ViewStyle, TextStyle, ViewToken } from 'react-native';
+import { MarkedDays, ThemeType as MonthThemeType } from 'react-native-month';
 
 export type RangeType = {
   endDate?: Date;
@@ -8,7 +9,7 @@ export type RangeType = {
 
 export type LocaleType = 'es' | 'en' | 'fr' | 'br' | 'zh';
 
-export type ThemeType = {
+export interface ThemeType extends MonthThemeType {
   activeDayColor?: string;
   activeDayContainerStyle?: ViewStyle;
   activeDayTextStyle?: TextStyle;
@@ -26,10 +27,7 @@ export type ThemeType = {
   startDateContainerStyle?: ViewStyle;
   todayContainerStyle?: ViewStyle;
   todayTextStyle?: TextStyle;
-  weekColumnsContainerStyle?: ViewStyle;
-  weekColumnStyle?: ViewStyle;
-  weekColumnTextStyle?: TextStyle;
-};
+}
 
 export type DayType = {
   date: Date;
@@ -61,6 +59,7 @@ export interface CalendarProps {
   firstDayMonday: boolean;
   initialListSize?: number;
   locale: LocaleType;
+  markedDays?: MarkedDays;
   maxDate?: Date;
   minDate?: Date;
   monthHeight: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8134,10 +8134,10 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
   integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
 
-react-native-month@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-month/-/react-native-month-1.0.3.tgz#76738fd77f8abe704fa5312f4ad0350822f0c309"
-  integrity sha512-RoD7/ingkugJ1T+bu2Q9+40AKfbhfjuwQwNtkPjxekOWQYXp8PDQvSgPsVcV9KlhwIKyFWroaOfyBp1XgvjaDw==
+react-native-month@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-month/-/react-native-month-1.0.4.tgz#7c55f35e7adacc071e56530350b60718d5722a89"
+  integrity sha512-oABtBzkGgS/QIURzXfW5TZUoMDeNSEruQEcO6HEY+L86zgyfxRoc38vHjh0y6CkZj0qvKHBC4oVQqk99ExnrBQ==
 
 react-native@0.63.3:
   version "0.63.3"


### PR DESCRIPTION
### Motivation

Provides the calendar component the ability to show multiple dots (maximum 3 dots) on each day component.

<img src="https://user-images.githubusercontent.com/3394748/122131952-5f622c00-ce10-11eb-9c55-89bf341c5a65.png" width="300" />

### Test plan

Run example project.
Change `markedDots` prop