### PR TITLE
fix(web): do not use initialScrollIndex on web as it is broken

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -306,7 +306,7 @@ export default class Calendar extends React.Component<CalendarProps, State> {
     return (
       <FlatList
         getItemLayout={!isWeb ? this.getItemLayout : undefined}
-        initialScrollIndex={this.state.initialScrollIndex}
+        initialScrollIndex={!isWeb ? this.state.initialScrollIndex : 0}
         viewabilityConfig={VIEWABILITY_CONFIG}
         removeClippedSubviews
         onViewableItemsChanged={this.handleViewableItemsChange}


### PR DESCRIPTION
### Motivation

Do not use initialScrollIndex on web as it is [broken](https://github.com/necolas/react-native-web/issues/2030)

| Before | After |
|:------:|:-----:|
| <img width="428" alt="Captura de Pantalla 2021-08-04 a la(s) 22 38 51" src="https://user-images.githubusercontent.com/3394748/128277486-3f79d07e-135f-4b7f-8ddf-61453a979f88.png"> | <img width="429" alt="Captura de Pantalla 2021-08-04 a la(s) 22 38 39" src="https://user-images.githubusercontent.com/3394748/128277523-9cb74c72-83c2-41bb-a62c-f82cbff7d8a7.png"> |
