### PR TITLE
refactor(Calendar): change to functional component + hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,30 +79,32 @@ import { Calendar } from 'react-native-calendario';
 
 ## API
 
-| Prop                       | Description                            | Required?            | Default       | Type             |
-| -------------------------- | -------------------------------------- | -------------------- | ------------- | ---------------- |
-| **`onChange`**             | Callback called when a day is pressed. | yes                  |               | Function         |
-| **`minDate`**              | Minimum date that can be selected.     | no                   | null          | Date             |
-| **`maxDate`**              | Maximum date that can be selected.     | no                   | null          | Date             |
-| **`startDate`**            | Selected start date                    | no                   | null          | Date             |
-| **`endDate`**              | Selected end date                      | requires _startDate_ | null          | Date             |
-| **`theme`**                | Calendar StyleSheet                    | no                   | null          | ThemeType        |
-| **`locale`**               | Calendar language                      | es, en, fr, br       | 'en'          | LocaleType       |
-| **`showWeekdays`**         | Show Week columns                      | no                   | true          | boolean          |
-| **`showMonthTitle`**       | Show Month title                       | no                   | true          | boolean          |
-| **`initialListSize`**      | FlatList initialNumToRender            | no                   | 2             | number           |
-| **`startingMonth`**        | First month to render                  | no                   | current month | 'YYYY-MM-DD'     |
-| **`numberOfMonths`**       | Number of months to render             | no                   | 12            | number           |
-| **`disableRange`**         | Turn off range date selection          | no                   | false         | boolean          |
-| **`firstDayMonday`**       | Monday as first day of the week        | no                   | false         | boolean          |
-| **`monthHeight`**          | Change Month row height                | no                   | 370           | number           |
-| **`markedDays`**           | Multi-dot support on Day component     | no                   | undefined     | MarkedDays       |
-| **`disabledDays`**         | Disabled days                          | no                   | null          | {[string]: any } |
-| **`renderDayContent`**     | Render custom Day content              | no                   | null          | Function         |
-| **`renderAllMonths`**      | Use this for web, render all months    | no                   | null          | boolean          |
-| **`extraData`**            | FlatList extraData                     | no                   | null          | any              |
-| **`viewableItemsChanged`** | handleViewableItemsChange callback     | no                   | null          | Function         |
-| **`disableOffsetDays`**    | Remove offset Days.                    | no                   | false         | boolean          |
+| Prop                        | Description                            | Required?            | Default       | Type             |
+| --------------------------- | -------------------------------------- | -------------------- | ------------- | ---------------- |
+| **`onChange`** (deprecated) | Callback called when a day is pressed. | no                   |               | Function         |
+| **`onPress`**               | Callback called when a day is pressed. | yes                  |               | (Date) => void   |
+| **`minDate`**               | Minimum date that can be selected.     | no                   | null          | Date             |
+| **`maxDate`**               | Maximum date that can be selected.     | no                   | null          | Date             |
+| **`startDate`**             | Selected start date                    | no                   | null          | Date             |
+| **`endDate`**               | Selected end date                      | requires _startDate_ | null          | Date             |
+| **`theme`**                 | Calendar StyleSheet                    | no                   | null          | ThemeType        |
+| **`locale`**                | Calendar language                      | es, en, fr, br       | 'en'          | LocaleType       |
+| **`dayNames`**              | Array of day names                     | no                   | []            | string[]         |
+| **`monthNames`**            | Array of names of each mo              | no                   | []            | string[]         |
+| **`showWeekdays`**          | Show Week columns                      | no                   | true          | boolean          |
+| **`showMonthTitle`**        | Show Month title                       | no                   | true          | boolean          |
+| **`initialListSize`**       | FlatList initialNumToRender            | no                   | 2             | number           |
+| **`startingMonth`**         | First month to render                  | no                   | current month | 'YYYY-MM-DD'     |
+| **`numberOfMonths`**        | Number of months to render             | no                   | 12            | number           |
+| **`disableRange`**          | Turn off range date selection          | no                   | false         | boolean          |
+| **`firstDayMonday`**        | Monday as first day of the week        | no                   | false         | boolean          |
+| **`monthHeight`**           | Change Month row height                | no                   | 370           | number           |
+| **`markedDays`**            | Multi-dot support on Day component     | no                   | undefined     | MarkedDays       |
+| **`disabledDays`**          | Disabled days                          | no                   | null          | {[string]: any } |
+| **`renderDayContent`**      | Render custom Day content              | no                   | null          | Function         |
+| **`renderAllMonths`**       | Use this for web, render all months    | no                   | null          | boolean          |
+| **`viewableItemsChanged`**  | handleViewableItemsChange callback     | no                   | null          | Function         |
+| **`disableOffsetDays`**     | Remove offset Days.                    | no                   | false         | boolean          |
 
 ## License
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { View, Text, StatusBar, SafeAreaView } from 'react-native';
-import {
-  Calendar,
-  DayType,
-  ThemeType,
-  RangeType,
-} from 'react-native-calendario';
+import { View, Text, StatusBar, SafeAreaView, StyleSheet } from 'react-native';
+import { Calendar, DayType, ThemeType } from 'react-native-calendario';
 import moment from 'moment';
 import { MarkedDays } from 'react-native-month';
+
+const styles = StyleSheet.create({
+  customDayContent: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
 
 const THEME: ThemeType = {
   monthTitleTextStyle: {
@@ -60,20 +62,21 @@ const DISABLED_DAYS = {
 type Props = {};
 
 type State = {
-  minDate: Date;
-  maxDate: Date;
-  startDate: Date;
+  minDate?: Date;
+  maxDate?: Date;
+  startDate?: Date;
   endDate?: Date;
 };
 
-const START_DATE_1 = '2020-03-10';
+const START_DATE_1 = '2020-01-10';
 const END_DATE_1 = '2020-04-15';
-const MIN_DATE_1 = '2020-03-12';
-const MAX_DATE_1 = '2020-04-10';
+const MIN_DATE_1 = '2020-01-02';
+const MAX_DATE_1 = '2020-04-20';
 
 const FORMAT = 'YYYY-MM-DD';
 
 const INITIAL_STATE = {
+  disableRange: false,
   startDate: moment(START_DATE_1, FORMAT).toDate(),
   endDate: moment(END_DATE_1, FORMAT).toDate(),
   minDate: moment(MIN_DATE_1, FORMAT).toDate(),
@@ -100,18 +103,33 @@ export default class App extends React.PureComponent<Props, State> {
     ...INITIAL_STATE,
   };
 
-  onChange = ({ startDate, endDate }: RangeType) =>
-    this.setState({ startDate, endDate });
+  handlePress = (date: Date) => {
+    const { disableRange, startDate, endDate } = this.state;
+
+    if (disableRange) {
+      this.setState({ startDate: date });
+    } else {
+      if (startDate) {
+        if (endDate) {
+          this.setState({ startDate: date, endDate: undefined });
+        } else if (date < startDate!) {
+          this.setState({ startDate: date });
+        } else if (date > startDate!) {
+          this.setState({ endDate: date });
+        } else {
+          this.setState({ startDate: date, endDate: date });
+          console.log('update 4');
+        }
+      } else {
+        this.setState({ startDate: date });
+      }
+    }
+  };
 
   renderDayContent = (item: DayType) => {
     const { isActive, date } = item;
     return (
-      <View
-        style={{
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
+      <View style={styles.customDayContent}>
         <Text
           style={[
             { color: isActive ? 'green' : 'grey' },
@@ -121,7 +139,7 @@ export default class App extends React.PureComponent<Props, State> {
         >
           {date.getDate()}
         </Text>
-        <Text style={{ fontSize: 7 }}>asd</Text>
+        <Text>{item.date.getDate()}</Text>
       </View>
     );
   };
@@ -135,18 +153,18 @@ export default class App extends React.PureComponent<Props, State> {
           }}
         >
           <Calendar
-            disableRange
+            onPress={this.handlePress}
+            disableRange={this.state.disableRange}
             minDate={this.state.minDate}
             maxDate={this.state.maxDate}
             startDate={this.state.startDate}
             endDate={this.state.endDate}
-            startingMonth="2020-01-10"
+            startingMonth="2019-11-10"
             markedDays={markedDays}
             monthHeight={370}
-            numberOfMonths={24}
-            renderAllMonths
+            numberOfMonths={100}
             initialListSize={4}
-            onChange={this.onChange}
+            firstDayMonday
             theme={THEME}
             disabledDays={DISABLED_DAYS}
             // renderDayContent={this.renderDayContent}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/core": "7.13.10",
     "@babel/runtime": "7.13.10",
     "@react-native-community/eslint-config": "^3.0.1",
+    "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "25.1.4",
     "@types/react": "16.9.52",
     "@types/react-native": "0.63.25",

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,20 +1,12 @@
-import * as React from 'react';
+import React, { useCallback, useRef, useState, useMemo } from 'react';
 import { FlatList, Platform } from 'react-native';
 import moment from 'moment';
 
 import Month from './Month';
-import { isValidDate } from '../utils/date';
+import useMonths from '../hooks/use-months';
+import useRange from '../hooks/use-range';
+import { getMonthIndex } from '../utils/date';
 import { CalendarProps, ViewableItemsType } from '../types';
-
-interface State {
-  firstMonthToRender: Date;
-  months: any[];
-  firstViewableIndex: number;
-  lastViewableIndex: number;
-  initialScrollIndex: number;
-  startDate?: Date;
-  endDate?: Date;
-}
 
 const NUMBER_OF_MONTHS = 12;
 const MONTH_HEIGHT = 370;
@@ -27,300 +19,202 @@ const VIEWABILITY_CONFIG = {
   minimumViewTime: 32,
 };
 
-export default class Calendar extends React.Component<CalendarProps, State> {
-  static defaultProps = {
-    numberOfMonths: NUMBER_OF_MONTHS,
-    startingMonth: moment().format('YYYY-MM-DD'),
-    initialListSize: INITIAL_LIST_SIZE,
-    showWeekdays: true,
-    showMonthTitle: true,
-    theme: {},
-    locale: 'en',
-    monthNames: [],
-    dayNames: [],
-    disableRange: false,
-    firstDayMonday: false,
-    monthHeight: MONTH_HEIGHT,
-    disableOffsetDays: false,
-    viewableRangeOffset: VIEWABLE_RANGE_OFFSET,
-  };
+export default function Calendar(props: CalendarProps) {
+  const {
+    numberOfMonths = NUMBER_OF_MONTHS,
+    startingMonth = moment().format('YYYY-MM-DD'),
+    initialListSize = INITIAL_LIST_SIZE,
+    showWeekdays = true,
+    showMonthTitle = true,
+    theme = {},
+    locale = 'en',
+    disableRange = false,
+    firstDayMonday = false,
+    monthHeight = MONTH_HEIGHT,
+    disableOffsetDays = false,
+    viewableRangeOffset = VIEWABLE_RANGE_OFFSET,
+    monthNames,
+    onPress,
+    dayNames,
+    startDate,
+    endDate,
+  } = props;
 
-  constructor(props: CalendarProps) {
-    super(props);
+  const [firstViewableIndex, setFirstViewableIndex] = useState(0);
+  const [lastViewableIndex, setLastViewableIndex] = useState(
+    INITIAL_LIST_SIZE + viewableRangeOffset!
+  );
+  const listReference = useRef<FlatList>(null);
 
-    this.state = {
-      firstMonthToRender: new Date(),
-      months: [],
-      initialScrollIndex: 0,
-      startDate: undefined,
-      endDate: undefined,
-      firstViewableIndex: 0,
-      lastViewableIndex: INITIAL_LIST_SIZE + props.viewableRangeOffset!,
-    };
-  }
-
-  UNSAFE_componentWillMount() {
-    const { numberOfMonths, startingMonth, startDate, endDate } = this.props;
-    let { firstMonthToRender } = this.state;
-
-    if (startingMonth && isValidDate(new Date(startingMonth))) {
-      firstMonthToRender = moment(startingMonth, 'YYYY-MM-DD').toDate();
-    }
-
-    let start: Date | undefined;
-
-    if (startDate && isValidDate(new Date(startDate))) {
-      start = moment(startDate, 'YYYY-MM-DD').toDate();
-
-      if (
-        start >
-        moment(firstMonthToRender).add(numberOfMonths, 'months').toDate()
-      ) {
-        start = undefined;
-      }
-    }
-
-    const end =
-      endDate && isValidDate(new Date(endDate))
-        ? moment(endDate, 'YYYY-MM-DD').toDate()
-        : undefined;
-
-    const months = new Array(numberOfMonths);
-
-    let firstMonthIndex = 0;
-
-    if (start) {
-      const monthIndex = this.getMonthIndex(start, months, firstMonthToRender);
-      if (monthIndex !== null) {
-        firstMonthIndex = monthIndex;
-      }
-    }
-
-    this.setState({
-      firstMonthToRender,
-      initialScrollIndex: firstMonthIndex,
-      months,
-      startDate: start,
-      endDate: end,
-    });
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps: CalendarProps) {
-    const { startDate, months, firstMonthToRender } = this.state;
-    const nextStartDate =
-      nextProps.startDate && nextProps.startDate instanceof Date
-        ? nextProps.startDate
-        : undefined;
-    const endDate =
-      nextProps.endDate && nextProps.endDate instanceof Date
-        ? nextProps.endDate
-        : undefined;
-
-    if (startDate !== nextStartDate || this.state.endDate !== endDate) {
-      this.setState(
-        {
-          startDate: nextStartDate,
-          endDate,
-        },
-        () => {
-          if (
-            this.listReference &&
-            nextStartDate &&
-            startDate !== nextStartDate
-          ) {
-            const monthIndex = this.getMonthIndex(
-              nextStartDate,
-              months,
-              firstMonthToRender
-            );
-            if (monthIndex !== null) {
-              this.listReference.scrollToIndex({ index: monthIndex });
-            }
-          }
-        }
-      );
-    }
-  }
-
-  shouldComponentUpdate(nextProps: CalendarProps, nextState: State): boolean {
-    return (
-      this.state.months.length !== nextState.months.length ||
-      this.state.startDate !== nextState.startDate ||
-      this.state.firstViewableIndex !== nextState.firstViewableIndex ||
-      this.state.lastViewableIndex !== nextState.lastViewableIndex ||
-      this.state.endDate !== nextState.endDate ||
-      this.props.minDate !== nextProps.minDate ||
-      this.props.maxDate !== nextProps.maxDate ||
-      this.props.startingMonth !== nextProps.startingMonth ||
-      this.props.renderDayContent !== nextProps.renderDayContent
-    );
-  }
-
-  private listReference?: FlatList<any> | null | undefined;
-
-  getItemLayout = (
-    _data: any,
-    index: number
-  ): { length: number; offset: number; index: number } => ({
-    length: this.props.monthHeight,
-    offset: this.props.monthHeight * index,
-    index,
+  const { months, firstMonth: firstMonthToRender } = useMonths({
+    numberOfMonths,
+    startingMonth,
   });
 
-  keyExtractor = (_item: any, index: number): string => String(index);
+  const { start: localStartDate, end: localEndDate } = useRange({
+    startDate,
+    endDate,
+    firstMonthToRender,
+    numberOfMonths,
+  });
 
-  handleViewableItemsChange = (info: ViewableItemsType) => {
-    if (this.props.viewableItemsChanged) {
-      this.props.viewableItemsChanged(info);
-    }
+  const firstMonthIndex = useMemo(() => {
+    if (localStartDate) {
+      const monthIndex = getMonthIndex(
+        firstMonthToRender,
+        localStartDate,
+        months,
+        numberOfMonths
+      );
 
-    if (this.props.renderAllMonths) {
-      return;
-    }
-
-    const { viewableItems } = info;
-
-    if (viewableItems.length > 0) {
-      const {
-        0: firstViewableItem,
-        length: l,
-        [l - 1]: lastViewableItem,
-      } = viewableItems;
-
-      const { firstViewableIndex, lastViewableIndex } = this.state;
-      if (
-        firstViewableIndex !== firstViewableItem.index ||
-        lastViewableIndex !== lastViewableItem.index
-      ) {
-        this.setState({
-          firstViewableIndex: firstViewableItem.index!,
-          lastViewableIndex: lastViewableItem.index! + VIEWABLE_RANGE_OFFSET,
-        });
-      }
-    }
-  };
-
-  handlePressDay = (date: Date) => {
-    const { startDate, endDate } = this.state;
-    let newStartDate;
-    let newEndDate;
-
-    if (this.props.disableRange) {
-      newStartDate = date;
-      newEndDate = undefined;
-    } else if (startDate) {
-      if (endDate) {
-        newStartDate = date;
-        newEndDate = undefined;
-      } else if (date < startDate!) {
-        newStartDate = date;
-      } else if (date > startDate!) {
-        newStartDate = startDate;
-        newEndDate = date;
-      } else {
-        newStartDate = date;
-        newEndDate = date;
-      }
-    } else {
-      newStartDate = date;
-    }
-
-    const newRange = {
-      startDate: newStartDate as Date,
-      endDate: newEndDate,
-    };
-
-    this.setState(newRange, () => this.props.onChange(newRange));
-  };
-
-  setReference = (ref: any) => {
-    if (ref) {
-      this.listReference = ref;
-      if (this.props.calendarListRef) {
-        this.props.calendarListRef(ref);
-      }
-    }
-  };
-
-  getMonthIndex = (date: Date, months: any[], firstMonthToRender: Date) => {
-    const { numberOfMonths } = this.props;
-
-    const firstMonth = moment(firstMonthToRender);
-    const lastMonth = firstMonth.clone().add(numberOfMonths, 'months');
-
-    if (
-      date >= firstMonth.toDate() &&
-      date <= lastMonth.endOf('month').toDate()
-    ) {
-      const monthIndex = moment(date).diff(firstMonth, 'months');
-
-      if (monthIndex >= 0 && monthIndex <= months.length) {
+      if (monthIndex !== null) {
         return monthIndex;
       }
     }
 
-    return null;
-  };
+    return 0;
+  }, [firstMonthToRender, localStartDate, months, numberOfMonths]);
 
-  renderMonth = ({ index }: { index: number }) => {
-    const { firstMonthToRender } = this.state;
-    const month = moment(firstMonthToRender).add(index, 'months');
+  const getItemLayout = useCallback(
+    (
+      _data: any,
+      index: number
+    ): { length: number; offset: number; index: number } => ({
+      length: monthHeight,
+      offset: monthHeight * index,
+      index,
+    }),
+    [monthHeight]
+  );
 
-    return (
-      <Month
-        month={month.month()}
-        year={month.year()}
-        index={index}
-        firstMonthToRender={this.state.firstMonthToRender}
-        monthNames={this.props.monthNames}
-        onPress={this.handlePressDay}
-        theme={this.props.theme}
-        renderAllMonths={this.props.renderAllMonths}
-        showWeekdays={this.props.showWeekdays}
-        showMonthTitle={this.props.showMonthTitle}
-        locale={this.props.locale}
-        dayNames={this.props.dayNames}
-        height={this.props.monthHeight}
-        firstDayMonday={this.props.firstDayMonday}
-        renderDayContent={this.props.renderDayContent}
-        markedDays={this.props.markedDays}
-        minDate={this.props.minDate}
-        maxDate={this.props.maxDate}
-        startDate={this.state.startDate}
-        endDate={this.state.endDate}
-        disableRange={this.props.disableRange}
-        disabledDays={this.props.disabledDays}
-        disableOffsetDays={this.props.disableOffsetDays}
-        firstViewableIndex={this.state.firstViewableIndex}
-        lastViewableIndex={this.state.lastViewableIndex}
-        viewableRangeOffset={this.props.viewableRangeOffset!}
-      />
-    );
-  };
+  const keyExtractor = useCallback(
+    (_item: any, index: number): string => String(index),
+    []
+  );
 
-  render() {
-    const { numberOfMonths, initialListSize } = this.props;
-    const isWeb = Platform.OS === 'web';
-    const initialNumToRender = isWeb ? numberOfMonths : initialListSize;
+  const onViewableItemsChanged = useCallback(
+    (info: ViewableItemsType) => {
+      if (props.viewableItemsChanged) {
+        props.viewableItemsChanged(info);
+      }
 
-    return (
-      <FlatList
-        getItemLayout={!isWeb ? this.getItemLayout : undefined}
-        initialScrollIndex={!isWeb ? this.state.initialScrollIndex : 0}
-        viewabilityConfig={VIEWABILITY_CONFIG}
-        removeClippedSubviews
-        onViewableItemsChanged={this.handleViewableItemsChange}
-        initialNumToRender={initialNumToRender}
-        keyExtractor={this.keyExtractor}
-        renderItem={this.renderMonth}
-        extraData={{
-          ...this.state,
-          minDate: this.props.minDate,
-          maxDate: this.props.maxDate,
-        }}
-        data={this.state.months}
-        ref={this.setReference}
-      />
-    );
-  }
+      if (props.renderAllMonths) {
+        return;
+      }
+
+      const { viewableItems } = info;
+
+      if (viewableItems.length > 0) {
+        const {
+          0: firstViewableItem,
+          length: l,
+          [l - 1]: lastViewableItem,
+        } = viewableItems;
+
+        if (
+          firstViewableIndex !== firstViewableItem.index ||
+          lastViewableIndex !== lastViewableItem.index
+        ) {
+          setFirstViewableIndex(firstViewableItem.index!);
+          setLastViewableIndex(lastViewableItem.index! + VIEWABLE_RANGE_OFFSET);
+        }
+      }
+    },
+    [firstViewableIndex, lastViewableIndex, props]
+  );
+
+  const viewabilityConfigCallbackPairs = useRef([
+    {
+      viewabilityConfig: VIEWABILITY_CONFIG,
+      onViewableItemsChanged,
+    },
+  ]);
+
+  const handlePress = useCallback(
+    (date: Date) => {
+      if (onPress) {
+        onPress(date);
+      }
+    },
+    [onPress]
+  );
+
+  const renderMonth = useCallback(
+    ({ index }: { index: number }) => {
+      const month = moment(firstMonthToRender).add(index, 'months');
+
+      return (
+        <Month
+          month={month.month()}
+          year={month.year()}
+          index={index}
+          firstMonthToRender={firstMonthToRender}
+          monthNames={monthNames}
+          onPress={handlePress}
+          theme={theme}
+          renderAllMonths={props.renderAllMonths}
+          showWeekdays={showWeekdays}
+          showMonthTitle={showMonthTitle}
+          locale={locale}
+          dayNames={dayNames}
+          height={monthHeight}
+          firstDayMonday={firstDayMonday}
+          renderDayContent={props.renderDayContent}
+          markedDays={props.markedDays}
+          minDate={props.minDate}
+          maxDate={props.maxDate}
+          startDate={localStartDate}
+          endDate={localEndDate}
+          disableRange={disableRange}
+          disabledDays={props.disabledDays}
+          disableOffsetDays={disableOffsetDays}
+          firstViewableIndex={firstViewableIndex}
+          lastViewableIndex={lastViewableIndex}
+          viewableRangeOffset={viewableRangeOffset!}
+        />
+      );
+    },
+    [
+      dayNames,
+      disableOffsetDays,
+      disableRange,
+      firstDayMonday,
+      firstMonthToRender,
+      firstViewableIndex,
+      handlePress,
+      lastViewableIndex,
+      localEndDate,
+      localStartDate,
+      locale,
+      monthHeight,
+      monthNames,
+      props.disabledDays,
+      props.markedDays,
+      props.maxDate,
+      props.minDate,
+      props.renderAllMonths,
+      props.renderDayContent,
+      showMonthTitle,
+      showWeekdays,
+      theme,
+      viewableRangeOffset,
+    ]
+  );
+
+  const isWeb = Platform.OS === 'web';
+  const initialNumToRender = isWeb ? numberOfMonths : initialListSize;
+
+  return (
+    <FlatList
+      getItemLayout={!isWeb ? getItemLayout : undefined}
+      initialScrollIndex={!isWeb ? firstMonthIndex : 0}
+      removeClippedSubviews
+      initialNumToRender={initialNumToRender}
+      keyExtractor={keyExtractor}
+      viewabilityConfigCallbackPairs={viewabilityConfigCallbackPairs.current}
+      renderItem={renderMonth}
+      data={months}
+      ref={listReference}
+    />
+  );
 }

--- a/src/components/Month/index.tsx
+++ b/src/components/Month/index.tsx
@@ -57,7 +57,7 @@ const MonthTitle = React.memo<MonthTitleProps>(
 );
 
 interface Props extends MonthProps {
-  monthNames: string[];
+  monthNames?: string[];
   firstMonthToRender: Date;
   firstViewableIndex: number;
   lastViewableIndex: number;

--- a/src/hooks/__tests__/use-months.test.ts
+++ b/src/hooks/__tests__/use-months.test.ts
@@ -1,0 +1,23 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useMonths from '../use-months';
+
+describe('useMonths', () => {
+  it('should return correct starting month', () => {
+    const startingMonth = '2020-02-02';
+    const numberOfMonths = 10;
+    const { result } = renderHook(() =>
+      useMonths({ startingMonth, numberOfMonths })
+    );
+
+    expect(result.current.firstMonth.getMonth()).toBe(1);
+    expect(result.current.months.length).toBe(10);
+  });
+
+  it('should return default starting month', () => {
+    const numberOfMonths = 12;
+    const { result } = renderHook(() => useMonths({ numberOfMonths }));
+
+    expect(result.current.firstMonth.getMonth()).toBe(new Date().getMonth());
+    expect(result.current.months.length).toBe(12);
+  });
+});

--- a/src/hooks/__tests__/use-range.test.ts
+++ b/src/hooks/__tests__/use-range.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react-hooks';
+import moment from 'moment';
+
+import useRange from '../use-range';
+
+describe('useRange', () => {
+  it('should return no range', () => {
+    const numberOfMonths = 10;
+    const firstMonthToRender = new Date();
+    const { result } = renderHook(() =>
+      useRange({ firstMonthToRender, numberOfMonths })
+    );
+
+    expect(result.current.start).toBeUndefined();
+    expect(result.current.end).toBeUndefined();
+  });
+
+  it('should return defined range between numberOfMonths', () => {
+    const numberOfMonths = 10;
+    const firstMonthToRender = new Date();
+    const startDate = moment().add(1, 'day').toDate();
+    const endDate = moment().add(10, 'day').toDate();
+    const { result } = renderHook(() =>
+      useRange({ firstMonthToRender, numberOfMonths, startDate, endDate })
+    );
+
+    expect(result.current.start).toBeDefined();
+    expect(result.current.end).toBeDefined();
+  });
+
+  it('should return no range for start/end date out of month range', () => {
+    const numberOfMonths = 2;
+    const firstMonthToRender = new Date();
+    const startDate = moment().add(3, 'month').toDate();
+    const endDate = moment().add(4, 'month').toDate();
+
+    const { result } = renderHook(() =>
+      useRange({ firstMonthToRender, numberOfMonths, startDate, endDate })
+    );
+
+    expect(result.current.start).toBeUndefined();
+    expect(result.current.end).toBeUndefined();
+  });
+});

--- a/src/hooks/use-months.ts
+++ b/src/hooks/use-months.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import moment from 'moment';
+
+import { isValidDate } from '../utils/date';
+import { CalendarProps } from '../types';
+
+interface Input
+  extends Pick<CalendarProps, 'startingMonth' | 'numberOfMonths'> {}
+
+interface Result {
+  firstMonth: Date;
+  months: any[];
+}
+
+export default function useMonths({
+  startingMonth,
+  numberOfMonths,
+}: Input): Result {
+  return useMemo(() => {
+    const firstMonth =
+      startingMonth && isValidDate(new Date(startingMonth))
+        ? moment(startingMonth, 'YYYY-MM-DD').toDate()
+        : new Date();
+
+    return {
+      firstMonth,
+      months: new Array(numberOfMonths),
+    };
+  }, [numberOfMonths, startingMonth]);
+}

--- a/src/hooks/use-range.ts
+++ b/src/hooks/use-range.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import moment from 'moment';
+
+import { isValidDate } from '../utils/date';
+import { CalendarProps } from '../types';
+
+interface Input
+  extends Pick<CalendarProps, 'startDate' | 'endDate' | 'numberOfMonths'> {
+  firstMonthToRender: Date;
+}
+
+interface Result {
+  start?: Date;
+  end?: Date;
+}
+
+export default function useRange({
+  startDate,
+  endDate,
+  numberOfMonths,
+  firstMonthToRender,
+}: Input): Result {
+  return useMemo(() => {
+    let start: Date | undefined;
+
+    if (startDate && isValidDate(new Date(startDate))) {
+      start = moment(startDate, 'YYYY-MM-DD').toDate();
+
+      if (
+        start >
+        moment(firstMonthToRender).add(numberOfMonths, 'months').toDate()
+      ) {
+        start = undefined;
+      }
+    }
+
+    const end =
+      endDate && isValidDate(new Date(endDate))
+        ? moment(endDate, 'YYYY-MM-DD').toDate()
+        : undefined;
+
+    return {
+      start,
+      end,
+    };
+  }, [endDate, firstMonthToRender, numberOfMonths, startDate]);
+}

--- a/src/hooks/use-range.ts
+++ b/src/hooks/use-range.ts
@@ -22,20 +22,20 @@ export default function useRange({
 }: Input): Result {
   return useMemo(() => {
     let start: Date | undefined;
+    const lastMonth = moment(firstMonthToRender)
+      .add(numberOfMonths, 'months')
+      .toDate();
 
     if (startDate && isValidDate(new Date(startDate))) {
       start = moment(startDate, 'YYYY-MM-DD').toDate();
 
-      if (
-        start >
-        moment(firstMonthToRender).add(numberOfMonths, 'months').toDate()
-      ) {
+      if (start > lastMonth) {
         start = undefined;
       }
     }
 
-    const end =
-      endDate && isValidDate(new Date(endDate))
+    let end =
+      endDate && isValidDate(new Date(endDate)) && endDate <= lastMonth
         ? moment(endDate, 'YYYY-MM-DD').toDate()
         : undefined;
 

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -51,6 +51,7 @@ export interface CalendarProps {
   /**
    * FlatList's ref
    *
+   * @deprecated
    * @memberof CalendarProps
    */
   calendarListRef?: (ref: RefObject<FlatList<any>>) => void;
@@ -61,7 +62,7 @@ export interface CalendarProps {
    * @type {string[]}
    * @memberof CalendarProps
    */
-  dayNames: string[];
+  dayNames?: string[];
 
   /**
    * Use this prop to disable individual days
@@ -89,7 +90,7 @@ export interface CalendarProps {
    * @default false
    * @memberof MonthProps
    */
-  disableRange: boolean;
+  disableRange?: boolean;
 
   /**
    * Selected end date
@@ -98,12 +99,21 @@ export interface CalendarProps {
    * @memberof CalendarProps
    */
   endDate?: Date;
+
+  /**
+   * FlatList's extraData prop
+   *
+   * @type {*}
+   * @deprecated
+   * @memberof CalendarProps
+   */
   extraData?: any;
 
   /**
    * Monday as first day of the week
    *
    * @type {boolean}
+   * @default false
    * @memberof CalendarProps
    */
   firstDayMonday: boolean;
@@ -115,7 +125,15 @@ export interface CalendarProps {
    * @memberof CalendarProps
    */
   initialListSize?: number;
-  locale: LocaleType;
+
+  /**
+   * Calendar language
+   *
+   * @type {LocaleType}
+   * @default en
+   * @memberof CalendarProps
+   */
+  locale?: LocaleType;
 
   /**
    * Multi-dot support on Day component
@@ -155,7 +173,7 @@ export interface CalendarProps {
    * @type {string[]}
    * @memberof CalendarProps
    */
-  monthNames: string[];
+  monthNames?: string[];
 
   /**
    * Number of months to render
@@ -164,7 +182,20 @@ export interface CalendarProps {
    * @memberof CalendarProps
    */
   numberOfMonths: number;
-  onChange: (range: RangeType) => void;
+
+  /**
+   * Day pressed
+   *
+   * @memberof CalendarProps
+   */
+  onPress: (date: Date) => void;
+
+  /**
+   * Use onPress
+   * @deprecated
+   * @memberof CalendarProps
+   */
+  onChange?: (range: RangeType) => void;
   renderDayContent?: (day: DayType) => ComponentType;
 
   /**
@@ -173,7 +204,7 @@ export interface CalendarProps {
    * @type {boolean}
    * @memberof CalendarProps
    */
-  showMonthTitle: boolean;
+  showMonthTitle?: boolean;
 
   /**
    * Show Week columns
@@ -181,7 +212,7 @@ export interface CalendarProps {
    * @type {boolean}
    * @memberof CalendarProps
    */
-  showWeekdays: boolean;
+  showWeekdays?: boolean;
 
   /**
    * Selected start date
@@ -206,7 +237,7 @@ export interface CalendarProps {
    * @memberof CalendarProps
    */
   renderAllMonths?: boolean;
-  theme: ThemeType;
+  theme?: ThemeType;
   viewableItemsChanged?: (viableItems: ViewableItemsType) => void;
   viewableRangeOffset?: number;
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import { LocaleType } from '../types';
 
 export function addDays(date: Date, days: number): Date {
@@ -19,6 +21,29 @@ export function isSameDate(one: Date, other: Date) {
     one.getMonth() === other.getMonth() &&
     one.getFullYear() === other.getFullYear()
   );
+}
+
+export function getMonthIndex(
+  firstMonth: Date,
+  date: Date,
+  months: any[],
+  numberOfMonths: number
+) {
+  const _firstMonth = moment(firstMonth);
+  const lastMonth = _firstMonth.clone().add(numberOfMonths, 'months');
+
+  if (
+    date >= _firstMonth.toDate() &&
+    date <= lastMonth.endOf('month').toDate()
+  ) {
+    const monthIndex = moment(date).diff(_firstMonth, 'months');
+
+    if (monthIndex >= 0 && monthIndex <= months.length) {
+      return monthIndex;
+    }
+  }
+
+  return null;
 }
 
 export function getMonthNames(locale?: LocaleType): string[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2014,6 +2014,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.12.5":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
@@ -2743,6 +2750,17 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@testing-library/react-hooks@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -2865,6 +2883,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.9.tgz#441a981da9d7be117042e1a6fd3dac4b30f55add"
+  integrity sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-native@0.63.25":
   version "0.63.25"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.25.tgz#a08bbe17a75cce993f52655a8fe75f30bf77e965"
@@ -2876,6 +2901,13 @@
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.0.tgz#d60f530ecf4c906721511603cca711b4fa830d41"
   integrity sha512-bN5EyjtuTY35xX7N5j0KP1vg5MpUXHpFTX6tGsqkNOthjNvet4VQOYRxFh+NT5cDSJrATmAFK9NLeYZ4mp/o0Q==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
   dependencies:
     "@types/react" "*"
 
@@ -2894,6 +2926,20 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.24"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.24.tgz#7e1b3f78d0fc53782543f9bce6d949959a5880bd"
+  integrity sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -8142,6 +8188,13 @@ react-dom@16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.3.tgz#276bfa05de8ac17b863587c9e0647522c25e2a0b"
+  integrity sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-is@^16.12.0, react-is@^16.8.4, react-is@^16.9.0:
   version "16.12.0"


### PR DESCRIPTION
### Motivation

Change old Calendar class component to a functional component

### Breaking Changes
- deprecate: `onChange` prop, use `onPress` prop
- deprecate: FlatList's `extraData` prop
- deprecate: `calendarListRef` prop

### Test plan
`src/hooks/__tests__/use-months.test.ts`
`src/hooks/__tests__/use-range.test.ts`
