### PR TITLE
fix: numberOfMonths and monthHeight props are not required

### DIFF
--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -157,7 +157,7 @@ export interface CalendarProps {
    * @type {number}
    * @memberof CalendarProps
    */
-  monthHeight: number;
+  monthHeight?: number;
 
   /**
    * Array of names of each month
@@ -173,7 +173,7 @@ export interface CalendarProps {
    * @type {number}
    * @memberof CalendarProps
    */
-  numberOfMonths: number;
+  numberOfMonths?: number;
 
   /**
    * Day pressed


### PR DESCRIPTION
fixes #384

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->